### PR TITLE
OPENEUROPA-1583: Add www-data to root group for ci and dev docker img.

### DIFF
--- a/scripts/install-ci.sh
+++ b/scripts/install-ci.sh
@@ -6,6 +6,8 @@ apt-get update
 # Install ci packages :
 apt-get install -y ${ci_packages}
 
+adduser www-data root
+
 apt-get clean
 rm -rf /var/lib/apt/lists/*
 rm -rf /tmp/*


### PR DESCRIPTION
## OPENEUROPA-1583

### Description
Add www-data to root group for ci and dev docker img to resolve the permission issues on dev env when we try to see and test a build of a site.

