### PR TITLE
Update install-full.sh

### DIFF
--- a/scripts/install-full.sh
+++ b/scripts/install-full.sh
@@ -12,10 +12,10 @@ php /tmp/composer-install --install-dir=/usr/bin --filename=composer
 # Install drush
 #wget https://github.com/drush-ops/drush/releases/download/$(wget -O - https://api.github.com/repos/drush-ops/drush/releases 2>/dev/null | grep tag_name | awk -F '"' '{print $4}' | grep -m 1 "^8")/drush.phar -O /usr/bin/drush
 ## Temporarily pin to version 8.2.3... 
-wget https://github.com/drush-ops/drush/releases/download/8.2.3/drush.phar -O /usr/bin/drush
+composer global require drush/drush "8.2.3"
 # Touch up
 ln -s /usr/bin/composer /usr/local/bin/composer
-ln -s /usr/bin/drush /usr/local/bin/drush
+ln -s $(realpath ~/.composer/vendor/bin/drush) /usr/local/bin/drush
 chmod +x /usr/bin/composer /usr/bin/drush
 drush @none dl registry_rebuild-7.x
 


### PR DESCRIPTION
Drush install using composer

Install drush using composer can fix the error
```<h1>Uncaught exception thrown in shutdown function.</h1><p>TYPO3\PharStreamWrapper\Exception: Unexpected file extension in &amp;quot;phar:///usr/bin/drush/commands/core/drupal&amp;quot; in Drupal\Core\Security\PharExtensionInterceptor-&gt;assert() (line 38 of /var/www/html/misc/typo3/drupal-security/PharExtensionInterceptor.php).</p><hr />```
