### PR TITLE
Limit memory for php-cli to 2Go

### DIFF
--- a/php_conf/95-cli.ini
+++ b/php_conf/95-cli.ini
@@ -1,1 +1,1 @@
-memory_limit = 4G
+memory_limit = 2G


### PR DESCRIPTION
FPFISSUPP-6573